### PR TITLE
Checkout proper libsodium branch before building

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -196,6 +196,7 @@ if [ ! -d libsodium ]; then
   git clone https://github.com/jedisct1/libsodium.git
 fi
 cd libsodium
+git checkout stable
 ./autogen.sh
 ./configure 
 make ${J}


### PR DESCRIPTION
It is now necessary to check out the stable branch of libsodium otherwise the `./configure` command will fail.